### PR TITLE
fix DELETE_EXISTING_COMMENT config option

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31605,6 +31605,10 @@ const {
 	GITHUB_DEPLOYMENT_ENV,
 } = __nccwpck_require__(5192)
 
+// Identify our comment(s) via this string so we can delete
+const OWN_COMMENT_ID_STRING =
+	'<!-- deploy comment from deploy-to-vercel-action, DO NOT EDIT THIS LINE -->'
+
 const init = () => {
 	const client = github.getOctokit(GITHUB_TOKEN).rest
 
@@ -31653,7 +31657,7 @@ const init = () => {
 		if (data.length < 1) return
 
 		const comment = data.find((comment) =>
-			comment.body?.includes('This pull request has been deployed to Vercel.')
+			comment.body?.includes(OWN_COMMENT_ID_STRING)
 		)
 		if (comment) {
 			await client.issues.deleteComment({
@@ -31718,8 +31722,8 @@ const init = () => {
 
 module.exports = {
 	init,
+	OWN_COMMENT_ID_STRING,
 }
-
 
 /***/ }),
 
@@ -32253,6 +32257,8 @@ const run = async () => {
 					? `\n| 🔍 Inspect	| <${deploymentURLs.inspector}> |`
 					: ''
 
+				commentMD += `\n${Github.OWN_COMMENT_ID_STRING}`
+
 				const comment = await github.createComment(commentMD)
 				core.info(`Comment created: ${comment.html_url}`)
 			}
@@ -32306,7 +32312,6 @@ const run = async () => {
 }
 
 run()
-
 module.exports = __webpack_exports__;
 /******/ })()
 ;

--- a/src/github.js
+++ b/src/github.js
@@ -12,6 +12,10 @@ const {
 	GITHUB_DEPLOYMENT_ENV,
 } = require('./config')
 
+// Identify our comment(s) via this string so we can delete
+const OWN_COMMENT_ID_STRING =
+	'<!-- deploy comment from deploy-to-vercel-action, DO NOT EDIT THIS LINE -->'
+
 const init = () => {
 	const client = github.getOctokit(GITHUB_TOKEN).rest
 
@@ -60,7 +64,7 @@ const init = () => {
 		if (data.length < 1) return
 
 		const comment = data.find((comment) =>
-			comment.body?.includes('This pull request has been deployed to Vercel.')
+			comment.body?.includes(OWN_COMMENT_ID_STRING)
 		)
 		if (comment) {
 			await client.issues.deleteComment({
@@ -125,4 +129,5 @@ const init = () => {
 
 module.exports = {
 	init,
+	OWN_COMMENT_ID_STRING,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -190,6 +190,8 @@ const run = async () => {
 					? `\n| 🔍 Inspect	| <${deploymentURLs.inspector}> |`
 					: ''
 
+				commentMD += `\n${Github.OWN_COMMENT_ID_STRING}`
+
 				const comment = await github.createComment(commentMD)
 				core.info(`Comment created: ${comment.html_url}`)
 			}


### PR DESCRIPTION
the `DELETE_EXISTING_COMMENT` config fails to work because we're looking for the following:

	comment.body?.includes('This pull request has been deployed to Vercel.')

but the comment adds a string with extra chars in the middle:

	This pull request (commit <SHA>) has been deployed to Vercel

a more robust method is to add a unique hidden string - that way our display messages can change without impacting the mechanism by which we're identifying our comments